### PR TITLE
Avoid using polyfill MutationObserver as ASAP implementation

### DIFF
--- a/lib/promise/asap.js
+++ b/lib/promise/asap.js
@@ -46,7 +46,7 @@ var scheduleFlush;
 // Decide what async method to use to triggering processing of queued callbacks:
 if (typeof process !== 'undefined' && {}.toString.call(process) === '[object process]') {
   scheduleFlush = useNextTick();
-} else if (BrowserMutationObserver) {
+} else if (BrowserMutationObserver && BrowserMutationObserver.toString().match(/\[native code\]/)) {
   scheduleFlush = useMutationObserver();
 } else {
   scheduleFlush = useSetTimeout();


### PR DESCRIPTION
Trying to use both this Promises polyfill and the [Polymer/MutationObservers](https://github.com/Polymer/MutationObservers) leads to some issues. I think we need to ensure that the ASAP implementation does not try to use a polyfilled version of `MutationObserver`.

I'm not sure I like this approach, but I'm open to suggestions. I'm worried about the cross platform aspect of `toString`. If we only cared about expliciting supporting [Polymer/MutationObservers](https://github.com/Polymer/MutationObservers), we could just check that `BrowserMutationObserver !== JsMutationObserver`.

/cc @jakearchibald @azakus
