### PR TITLE
Change asap mutation observer implementation to touch text node

### DIFF
--- a/lib/promise/asap.js
+++ b/lib/promise/asap.js
@@ -10,9 +10,11 @@ function useNextTick() {
 }
 
 function useMutationObserver() {
+  var iterations = 0;
+  var twiddle = document.createTextNode('');
+
   var observer = new BrowserMutationObserver(flush);
-  var element = document.createElement('div');
-  observer.observe(element, { attributes: true });
+  observer.observe(twiddle, { characterData: true });
 
   // Chrome Memory Leak: https://bugs.webkit.org/show_bug.cgi?id=93661
   window.addEventListener('unload', function(){
@@ -21,7 +23,7 @@ function useMutationObserver() {
   }, false);
 
   return function() {
-    element.setAttribute('drainQueue', 'drainQueue');
+    twiddle.textContent = iterations++;
   };
 }
 


### PR DESCRIPTION
Alternative PR to #1 as suggested by @azakus.

Opposed to setting attribute to the same value which may not trigger a mutation on buggy browsers or with a MutationObserver polyfill.

Hat tip to Polymer microtask.js
https://github.com/Polymer/platform-dev/blob/master/src/microtask.js

/cc @jakearchibald @azakus
