### PR TITLE
Fix document about IE catch issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ To use:
 var Promise = require('es6-promise').Promise;
 ```
 
-## Usage in IE<10
+## Usage in IE<9
 
-`catch` is a reserved word in IE<10, meaning `promise.catch(func)` throws a syntax error. To work around this, use a string to access the property:
+`catch` is a reserved word in IE<9, meaning `promise.catch(func)` throws a syntax error. To work around this, use a string to access the property:
 
 ```js
 promise['catch'](function(err) {


### PR DESCRIPTION
Hi, I've found a mistake on README.

IE 9 can use [promise.catch](http://jsbin.com/corahuhu/2/edit).
(IE Version 9.0.8112.16421 [modern.IE](http://modern.ie/))

[![ie9 - win7 snapshot 1 2014-05-24 17-14-18 2014-05-24 17-14-41](https://cloud.githubusercontent.com/assets/19714/3074008/18809916-e31c-11e3-9d10-ffcec1820972.png)](http://jsbin.com/corahuhu/2/edit)

[![browser support](https://ci.testling.com/azu/promise-catch-error.png)](https://ci.testling.com/azu/promise-catch-error)

The result from [azu/promise-catch-error](https://github.com/azu/promise-catch-error).
