### PR TITLE
Link to the ES6 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ES6-Promise (subset of [rsvp.js](https://github.com/tildeio/rsvp.js))
 
-This is a polyfill of the [ES6 Promise](https://github.com/domenic/promises-unwrapping). The implementation is a subset of [rsvp.js](https://github.com/tildeio/rsvp.js), if you're wanting extra features and more debugging options, check out the [full library](https://github.com/tildeio/rsvp.js).
+This is a polyfill of the [ES6 Promise](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-constructor). The implementation is a subset of [rsvp.js](https://github.com/tildeio/rsvp.js), if you're wanting extra features and more debugging options, check out the [full library](https://github.com/tildeio/rsvp.js).
 
 For API details and how to use promises, see the <a href="http://www.html5rocks.com/en/tutorials/es6/promises/">JavaScript Promises HTML5Rocks article</a>.
 


### PR DESCRIPTION
Quote from https://github.com/domenic/promises-unwrapping#status :

> This proposal has progressed to the Draft ECMAScript 6 Specification, which is available for review on the official ECMAScript wiki. When referencing the promises specification, you should reference the draft ECMAScript 6 spec, and not this repository.
