### PR TITLE
inform about minifiers and IE<9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ var Promise = require('es6-promise').Promise;
 
 ## Usage in IE<9
 
-`catch` is a reserved word in IE<9, meaning `promise.catch(func)` throws a syntax error. To work around this, use a string to access the property:
+`catch` is a reserved word in IE<9, meaning `promise.catch(func)` throws a syntax error. To work around this, you can use a string to access the property as shown in the following example.
+
+However, please remember that such technique is already provided by most common minifiers, making the resulting code safe for old browsres and production:
 
 ```js
 promise['catch'](function(err) {


### PR DESCRIPTION
Every minifier I know automatically wraps in strings ES3 reserved words when it comes to property access.  `obj.delete`, `obj.default`, `obj.catch`, these are always wrapped as `obj["delete"]`,  `obj["default"]`,  `obj["catch"]` and every other so IE<9 is a non real-word/production concern at all ( assuming developers will use minifiers and they should anyway )
