### PR TITLE
Use 'files' property to limit npm package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "bower": "^1.3.9",
     "brfs": "0.0.8",


### PR DESCRIPTION
Fixes #61.

Presuming `dist` is all that should be published, but #67 prevented me from being sure.
Let me know if there should be some other files included in the npm installation.
