### PR TITLE
IE8: use isArray.

### DIFF
--- a/lib/es6-promise/enumerator.js
+++ b/lib/es6-promise/enumerator.js
@@ -30,7 +30,7 @@ function Enumerator(Constructor, input) {
     makePromise(this.promise);
   }
 
-  if (Array.isArray(input)) {
+  if (isArray(input)) {
     this._input     = input;
     this.length     = input.length;
     this._remaining = input.length;


### PR DESCRIPTION
The function `isArray` is imported but not used. On IE 8, the method
`Array.isArray` doesn't exist and we get an error.