### PR TITLE
Do not polyfill under node.js v4.4.3

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -18,7 +18,7 @@ export default function polyfill() {
 
   var P = local.Promise;
 
-  if (P && Object.prototype.toString.call(P.resolve()) === '[object Promise]' && !P.cast) {
+  if (P && (Object.prototype.toString.call(P.resolve()) === '[object Promise]' || Object.prototype.toString.call(P.resolve()) === '[object Object]') && !P.cast) {
     return;
   }
 


### PR DESCRIPTION
Thanks for your useful module. We use it in [OpenPGP.js](https://github.com/openpgpjs/openpgpjs/).

The polyfill detection seems to be broken at least under the current node LTS (v4.4.3). See: https://github.com/openpgpjs/openpgpjs/issues/455

I debugged to understand why `global.Promise` is polyfilled even though node has native support for Promises. I found that `Object.prototype.toString.call(P.resolve())` returns `'[object Object]'` and not `'[object Promise]'` like in Chrome.

Perhaps there is a broader and more elegant way to fix the issue, but with this patch the native Promise function is no longer overriden in node.