### PR TITLE
Update download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For API details and how to use promises, see the <a href="http://www.html5rocks.
 
 ## Downloads
 
-* [es6-promise](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/es6-promise.js)
+* [es6-promise](https://github.com/stefanpenner/es6-promise/raw/master/dist/lib/es6-promise.js)
 * [es6-promise-min](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/es6-promise.min.js)
 
 ## Node.js


### PR DESCRIPTION
This only fixes one of the links.  The other link (es6-promise.min.js) is still a problem because no such file exists in dist/lib.

The link was obtained by following Github links to the "Raw" button for the appropriate file.