### PR TITLE
Update Broken Links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ For API details and how to use promises, see the <a href="http://www.html5rocks.
 
 ## Downloads
 
-* [es6-promise](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/es6-promise.js)
-* [es6-promise-min](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/es6-promise.min.js)
+* [es6-promise](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/lib/es6-promise.js)
+* [es6-promise-min](https://raw.githubusercontent.com/stefanpenner/es6-promise/master/dist/lib/es6-promise.min.js)
 
 ## Node.js
 


### PR DESCRIPTION
seems the libs were moved to `dist/lib/*` instead of `dist/*`

![capture d ecran 2016-07-27 a 00 27 10](https://cloud.githubusercontent.com/assets/38223/17163841/ef482608-5390-11e6-909d-c1e02df14de8.png)
