### PR TITLE
Increase compatiblity with faking time in test tools

### DIFF
--- a/lib/es6-promise/asap.js
+++ b/lib/es6-promise/asap.js
@@ -73,8 +73,11 @@ function useMessageChannel() {
 }
 
 function useSetTimeout() {
+  // Store setTimeout reference so es6-promise will be unaffected by
+  // other code modifying setTimeout (like sinon.useFakeTimers())
+  var globalSetTimeout = setTimeout;
   return function() {
-    setTimeout(flush, 1);
+    globalSetTimeout(flush, 1);
   };
 }
 


### PR DESCRIPTION
Caching a reference to the global setTimeout is necessary to be compatible with test libraries that fake time, like sinon.js
See https://github.com/taylorhakes/promise-polyfill/pull/15
