### PR TITLE
Supporting polyfill for WebMAF

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -19,14 +19,14 @@ export default function polyfill() {
   var P = local.Promise;
 
   if (P) {
-    var promisetoString = null;
+    var promiseToString = null;
     try {
-        promisetoString = Object.prototype.toString.call(P.resolve());
+        promiseToString = Object.prototype.toString.call(P.resolve());
     } catch(e) {
         // silently ignored
     }
 
-    if (promisetoString === '[object Promise]' && !P.cast){
+    if (promiseToString === '[object Promise]' && !P.cast){
         return;
     }
   }

--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -18,8 +18,17 @@ export default function polyfill() {
 
   var P = local.Promise;
 
-  if (P && Object.prototype.toString.call(P.resolve()) === '[object Promise]' && !P.cast) {
-    return;
+  if (P) {
+    var promisetoString = null;
+    try {
+        promisetoString = Object.prototype.toString.call(P.resolve());
+    } catch(e) {
+        // silently ignored
+    }
+
+    if (promisetoString === '[object Promise]' && !P.cast){
+        return;
+    }
   }
 
   local.Promise = Promise;


### PR DESCRIPTION
Hi everyone,

this is a fix for the [WebMAF framework](http://develop.scee.net/research-technology/), used for Playstation web apps development.

Their Promise implementation made impossible to call Promise.resolve() **without** a parameter. Therefore the app would crash with a "_TypeError: expecting at least one argument_" when executing those [3 lines](https://github.com/stefanpenner/es6-promise/blob/ad25a4b7a13e7724c8e3767b75df2660878da913/lib/es6-promise/polyfill.js#L21-L23).

So, I basically wrapped the second condition in a try/catch in order to call the resolve method safely. The error is currently silently ignored, as I don't think anything should be done at this point.