### PR TITLE
Avoid replacing non-native Promise implementation

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -18,7 +18,7 @@ export default function polyfill() {
 
   var P = local.Promise;
 
-  if (P && Object.prototype.toString.call(P.resolve()) === '[object Promise]' && !P.cast) {
+  if (P && P.resolve && P.resolve() && !P.cast) {
     return;
   }
 


### PR DESCRIPTION
Instead of checking for native implementation, check if the Promise
loosely behaves like a Promise (has a resolve method that, when
called, returns a truthy value. This is necessary when working with
e.g. Angular 2, which overrides/wraps the existing Promise library.

Fixes #224 