### PR TITLE
Fix auto.js polyfill

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -1,4 +1,4 @@
 // This file can be required in Browserify and Node.js for automatic polyfill
 // To use it:  require('es6-promise/auto');
 'use strict';
-module.exports = require('.').polyfill();
+module.exports = require('./').polyfill();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "dist",
     "lib",
+    "auto.js",
     "es6-promise.d.ts",
     "!dist/test"
   ],


### PR DESCRIPTION
* `auto.js` was not being published to NPM
* `require('.')` doesn't work on Node < 4

Fixes #238.