### PR TITLE
Fix auto.js for Node < 4 compatibility

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -1,4 +1,4 @@
 // This file can be required in Browserify and Node.js for automatic polyfill
 // To use it:  require('es6-promise/auto');
 'use strict';
-module.exports = require('.').polyfill();
+module.exports = require('./').polyfill();


### PR DESCRIPTION
Trying this again since the [last PR](https://github.com/stefanpenner/es6-promise/pull/239) got rekt...

* `require('.')` doesn't work on Node < 4
