### PR TITLE
fix npm SEO for 'promise polyfill'

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   },
   "keywords": [
     "promises",
+    "promise",
+    "polyfill",
     "futures"
   ],
   "author": "Yehuda Katz, Tom Dale, Stefan Penner and contributors (Conversion to ES6 API by Jake Archibald)",


### PR DESCRIPTION
This package *should* show up in this search: https://www.npmjs.com/search?q=promise%20polyfill