### PR TITLE
Prefer prepublishOnly to prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "ember test",
     "test:server": "ember test --server",
     "test:node": "ember build && mocha ./dist/test/browserify",
-    "prepublish": "ember build --environment production",
+    "prepublishOnly": "ember build --environment production",
     "lint": "jshint lib"
   },
   "repository": {


### PR DESCRIPTION
because `prepublish` is run on `npm install` also.
To make a production package on publishing to npm, `prepublishOnly` is better hook to do that.

https://docs.npmjs.com/misc/scripts#prepublish-and-prepare