### PR TITLE
Remove duplicate "validationError" function

### DIFF
--- a/lib/es6-promise/enumerator.js
+++ b/lib/es6-promise/enumerator.js
@@ -22,10 +22,6 @@ import { makePromise, PROMISE_ID } from './-internal';
 
 function validationError() {
   return new Error('Array Methods must be provided an Array');
-}
-
-function validationError() {
-  return new Error('Array Methods must be provided an Array');
 };
 
 export default class Enumerator {


### PR DESCRIPTION
I noticed that the `validationError` function [is declared twice](https://github.com/stefanpenner/es6-promise/blob/4abbe5edc6afb575ce8c3d03338eb7a15528e23e/lib/es6-promise/enumerator.js#L23-L29):

```js
function validationError() {
  return new Error('Array Methods must be provided an Array');
}

function validationError() {
  return new Error('Array Methods must be provided an Array');
};
```

This PR removes one of the two function declarations.