### PR TITLE
Remove duplicate validationError

### DIFF
--- a/lib/es6-promise/enumerator.js
+++ b/lib/es6-promise/enumerator.js
@@ -24,10 +24,6 @@ function validationError() {
   return new Error('Array Methods must be provided an Array');
 }
 
-function validationError() {
-  return new Error('Array Methods must be provided an Array');
-};
-
 export default class Enumerator {
   constructor(Constructor, input) {
     this._instanceConstructor = Constructor;


### PR DESCRIPTION
Without this, the latest Closure Compiler will error about a duplicate declaration when passing the `dist/*` files through it.