### PR TITLE
Reassign global Promise to es6-promise if Promise.prototype.finally() is undefined.

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -27,7 +27,9 @@ export default function polyfill() {
     }
 
     if (promiseToString === '[object Promise]' && !P.cast){
-      return;
+      if (typeof P.prototype.finally !== "undefined"){
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #330 .