### PR TITLE
Expose flush on Promise

### DIFF
--- a/lib/es6-promise/asap.js
+++ b/lib/es6-promise/asap.js
@@ -80,7 +80,7 @@ function useSetTimeout() {
 }
 
 const queue = new Array(1000);
-function flush() {
+export function flush() {
   for (let i = 0; i < len; i+=2) {
     let callback = queue[i];
     let arg = queue[i+1];

--- a/lib/es6-promise/promise.js
+++ b/lib/es6-promise/promise.js
@@ -10,7 +10,8 @@ import {
 import {
   asap,
   setAsap,
-  setScheduler
+  setScheduler,
+  flush
 } from './asap';
 
 import all from './promise/all';
@@ -428,4 +429,5 @@ Promise.reject = Reject;
 Promise._setScheduler = setScheduler;
 Promise._setAsap = setAsap;
 Promise._asap = asap;
+Promise._flush = flush;
 


### PR DESCRIPTION
I need to flush the queue synchronously to be able to use promises with indexeddb on some older platforms that don't check the microtask queue before closing active transactions (IE11 on Windows7), [like so](https://github.com/vector-im/hydrogen-web/blob/bwindels/idb-promises/src/matrix/storage/idb/utils.js#L55).

I considered using the already exposed `setScheduler` function but it would be hard to just flush the queue around the resolution of one promise without reimplementing the MutationObserver strategy, given that you can't assume which resolve will queue a microtask, and as I still want promises outside of idb requests to resolve async.

The changes are minimal, but the authors might or might not want to expose this. I'm happy to just keep this in a fork if not.