### PR TITLE
Polyfill if finally missing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bbc/interactive-tv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ES6-Promise (subset of [rsvp.js](https://github.com/tildeio/rsvp.js)) [![Build Status](https://travis-ci.org/stefanpenner/es6-promise.svg?branch=master)](https://travis-ci.org/stefanpenner/es6-promise)
+# ES6-Promise (subset of [rsvp.js](https://github.com/tildeio/rsvp.js))
+
+**With this fork the polyfill will also be applied if there is native `Promise` support but `Promise.prototype.finally` is missing.**
 
 This is a polyfill of the [ES6 Promise](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-constructor). The implementation is a subset of [rsvp.js](https://github.com/tildeio/rsvp.js) extracted by @jakearchibald, if you're wanting extra features and more debugging options, check out the [full library](https://github.com/tildeio/rsvp.js).
 

--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -26,7 +26,7 @@ export default function polyfill() {
       // silently ignored
     }
 
-    if (promiseToString === '[object Promise]' && !P.cast){
+    if (promiseToString === '[object Promise]' && !P.cast && typeof P.prototype.finally === 'function'){
       return;
     }
   }


### PR DESCRIPTION
Previously if a device had `Promise` but was missing `Promise.polyfill.finally`, the polyfill would not be applied and `finally` would be missing.